### PR TITLE
fix: ライセンスバッジをCC BY 4.0が正しく表示されるように更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # オブザーバビリティ成熟度モデル
 
-![License](https://img.shields.io/github/license/dmm-com/observability-maturity-model)
+[![License: CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-brightgreen.svg)](https://creativecommons.org/licenses/by/4.0/)
 
 DMM.comで策定・運用されている、組織のオブザーバビリティ能力を6つの評価軸で測定し、段階的な改善を支援するための成熟度モデルです。
 


### PR DESCRIPTION
## 概要
ライセンスバッジが「not identifiable by github」と表示される問題を修正しました。

## 問題の詳細
公開直後、README.mdのライセンスバッジが "license: not identifiable by github" と表示されていました。

### 原因
GitHubは標準的なライセンステンプレート（MIT、Apache 2.0など）のみを自動認識します。
Creative Commons Attribution 4.0 International (CC BY 4.0) はカスタム形式で記述されているため、
GitHubの自動認識対象外となっていました。

## 対応内容
shields.ioの直接バッジURLを使用するように変更しました。

### 変更点
- CC BY 4.0が明示的に表示される
- バッジの色をbrightgreen（明るい緑）に設定
- クリック可能なバッジとして、CC公式サイトへリンク
